### PR TITLE
Differentiate between multicast and topic response

### DIFF
--- a/Sources/VaporFCM/FirebaseResponse.swift
+++ b/Sources/VaporFCM/FirebaseResponse.swift
@@ -43,7 +43,7 @@ public struct FirebaseResponse {
 				return
 		}
 
-		var messageIds: [String] = []
+		var messageIds: [Any] = []
 		var errors: [FirebaseError] = []
 
 		/*


### PR DESCRIPTION
`FirebaseResponse` always returned `success`: `false`.

Two reasons:

1.) When using topics, the result (message_id) will not be wrapped into `results`. Instead it's inserted directly on root-level:

```
//Success example:
{
  "message_id": "1023456"
}

//failure example:
{
  "error": "TopicsMessageRateExceeded"
}
```

2.) The type of `message_id` within `dict` is not `String` but `Uint`, which resulted in the downcast to fail. I have removed that strict casting.

See: https://firebase.google.com/docs/cloud-messaging/send-message