### PR TITLE
Add different types of firebase response to different targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ sudo: required
 dist: trusty
 before_install:
   - if [ $TRAVIS_OS_NAME == "osx" ]; then
+      brew tap vapor/tap;
       brew tap vapor/homebrew-tap;
+      brew update;
       brew install ctls;
     fi
 install:

--- a/Sources/VaporFCM/DeviceToken.swift
+++ b/Sources/VaporFCM/DeviceToken.swift
@@ -23,6 +23,8 @@ extension DeviceToken: Targetable {
 	public var targetValue: String {
 		return rawValue
 	}
+
+	public typealias ResponseType = FirebaseDeviceResponse
 }
 
 extension DeviceToken: Equatable {

--- a/Sources/VaporFCM/Firebase.swift
+++ b/Sources/VaporFCM/Firebase.swift
@@ -47,13 +47,13 @@ public class Firebase {
 	///   - target: Firebase Device Token or Topic that you want to send your message to
 	/// - Returns: Synchronous response
 	/// - Throws: Serialization error when the message could not be serialized
-	public func send(message: Message, to target: Targetable) throws -> FirebaseResponse {
+	public func send<Target: Targetable>(message: Message, to target: Target) throws -> Target.ResponseType {
 		let requestBytes: Bytes = try serializer.serialize(message: message, target: target)
 		do {
 			let response = try requestAdapter.send(bytes: requestBytes, headers: generateHeaders(), url: pushUrl)
-			return FirebaseResponse(bytes: response.body.bytes ?? [], statusCode: response.status.statusCode)
+			return Target.ResponseType(bytes: response.body.bytes ?? [], statusCode: response.status.statusCode)
 		} catch {
-			return FirebaseResponse(error: error)
+			return Target.ResponseType(error: error)
 		}
 	}
 

--- a/Sources/VaporFCM/FirebaseDeviceResponse.swift
+++ b/Sources/VaporFCM/FirebaseDeviceResponse.swift
@@ -1,0 +1,29 @@
+// (c) 2017 Kajetan Michal Dabrowski
+// This code is licensed under MIT license (see LICENSE for details)
+
+import Foundation
+import Jay
+
+/// This is a response that you will get from Firebase
+public struct FirebaseDeviceResponse: FirebaseResponse {
+
+	/// Indicates if everything was successful
+	public let success: Bool
+
+	/// Error(s) that occured while sending a message
+	public let error: FirebaseError?
+
+	/// The message ids
+	public let messageIds: [String]
+
+	/// Message id is a string here
+	public typealias MessageIdType = String
+
+	// MARK: Initializers
+	public init(success: Bool, error: FirebaseError?, messageIds: [MessageIdType]) {
+		self.success = success
+		self.error = error
+		self.messageIds = messageIds
+	}
+
+}

--- a/Sources/VaporFCM/FirebaseResponse.swift
+++ b/Sources/VaporFCM/FirebaseResponse.swift
@@ -5,58 +5,63 @@ import Foundation
 import Jay
 
 /// This is a response that you will get from Firebase
-public struct FirebaseResponse {
+public protocol FirebaseResponse {
 
 	/// Indicates if everything was successful
-	public let success: Bool
+	var success: Bool { get }
 
 	/// Error(s) that occured while sending a message
-	public let error: FirebaseError?
+	var error: FirebaseError? { get }
 
-	// MARK: Internal and private methods
+	/// The type of a message ID (can be String or UInt)
+	associatedtype MessageIdType
 
-	private enum ResponseKey: String {
-		case result = "results"
-		case messageId = "message_id"
-		case error = "error"
+	/// The message ids
+	var messageIds: [MessageIdType] { get }
+
+	init(success: Bool, error: FirebaseError?, messageIds: [MessageIdType])
+}
+
+fileprivate enum FirebaseResponseKey: String {
+	case result = "results"
+	case messageId = "message_id"
+	case error = "error"
+}
+
+internal extension FirebaseResponse {
+
+	init(firebaseError: FirebaseError) {
+		self.init(success: false, error: firebaseError, messageIds: [])
 	}
 
-	internal init(firebaseError: FirebaseError) {
-		self.success = false
-		self.error = firebaseError
-	}
-
-	internal init(error: Error) {
+	init(error: Error) {
 		self.init(firebaseError: FirebaseError(error: error))
 	}
 
-	internal init(bytes: [UInt8], statusCode: Int) {
+	init(bytes: [UInt8], statusCode: Int) {
 		guard statusCode == 200 else {
-			self.success = false
-			self.error = FirebaseError(statusCode: statusCode)
+			self.init(success: false, error: FirebaseError(statusCode: statusCode), messageIds: [])
 			return
 		}
 		guard let json = try? Jay().anyJsonFromData(bytes),
 			let dict = json as? [String: Any] else {
-				self.success = false
-				self.error = .invalidData
+				self.init(success: false, error: .invalidData, messageIds: [])
 				return
 		}
 
-		var messageIds: [String] = []
+		var messageIds: [MessageIdType] = []
 		var errors: [FirebaseError] = []
 
-		let results = dict[ResponseKey.result.rawValue] as? [[String: Any]]
-		for result in results ?? [] {
-			if let id = result[ResponseKey.messageId.rawValue] as? String {
+		let results = (dict[FirebaseResponseKey.result.rawValue] as? [[String: Any]]) ?? [dict]
+		for result in results {
+			if let id = result[FirebaseResponseKey.messageId.rawValue] as? MessageIdType {
 				messageIds.append(id)
 			}
-			if let errorMessage = result[ResponseKey.error.rawValue] as? String {
+			if let errorMessage = result[FirebaseResponseKey.error.rawValue] as? String {
 				errors.append(FirebaseError(message: errorMessage))
 			}
 		}
 
-		self.success = errors.isEmpty && !messageIds.isEmpty
-		self.error = FirebaseError(multiple: errors)
+		self.init(success: errors.isEmpty && !messageIds.isEmpty, error: FirebaseError(multiple: errors), messageIds: messageIds)
 	}
 }

--- a/Sources/VaporFCM/FirebaseTopicResponse.swift
+++ b/Sources/VaporFCM/FirebaseTopicResponse.swift
@@ -1,0 +1,25 @@
+// (c) 2017 Kajetan Michal Dabrowski
+// This code is licensed under MIT license (see LICENSE for details)
+
+import Foundation
+import Jay
+
+public struct FirebaseTopicResponse: FirebaseResponse {
+	/// Indicates if everything was successful
+	public let success: Bool
+
+	/// Error(s) that occured while sending a message
+	public let error: FirebaseError?
+
+	/// The message ids
+	public let messageIds: [UInt]
+
+	/// Message id is UInt here
+	public typealias MessageIdType = UInt
+
+	public init(success: Bool, error: FirebaseError?, messageIds: [MessageIdType]) {
+		self.success = success
+		self.error = error
+		self.messageIds = messageIds
+	}
+}

--- a/Sources/VaporFCM/MessageSerializer.swift
+++ b/Sources/VaporFCM/MessageSerializer.swift
@@ -12,12 +12,12 @@ public class MessageSerializer {
 		case data = "data"
 	}
 
-	public func serialize(message: Message, target: Targetable) throws -> [UInt8] {
+	public func serialize<Target: Targetable>(message: Message, target: Target) throws -> [UInt8] {
 		let json: [String: Any] = serialize(message: message, target: target)
 		return try Jay(formatting: .minified).dataFromJson(jsonWrapper: JaySON(json))
 	}
 
-	public func serialize(message: Message, target: Targetable) -> [String: Any] {
+	public func serialize<Target: Targetable>(message: Message, target: Target) -> [String: Any] {
 		var json: [String: Any] = [:]
 		json[target.targetKey] = target.targetValue
 

--- a/Sources/VaporFCM/Targetable.swift
+++ b/Sources/VaporFCM/Targetable.swift
@@ -8,4 +8,7 @@ import Foundation
 public protocol Targetable {
 	var targetKey: String { get }
 	var targetValue: String { get }
+
+	/// The response type for this type of target
+	associatedtype ResponseType: FirebaseResponse
 }

--- a/Sources/VaporFCM/Topic.swift
+++ b/Sources/VaporFCM/Topic.swift
@@ -36,6 +36,8 @@ extension Topic: Targetable {
 			return "condition"
 		}
 	}
+
+	public typealias ResponseType = FirebaseTopicResponse
 }
 
 extension Topic: Equatable {

--- a/Tests/VaporFCMTests/FirebaseTests.swift
+++ b/Tests/VaporFCMTests/FirebaseTests.swift
@@ -11,6 +11,7 @@ class FirebaseTests: XCTestCase {
 
 	let exampleServerKey = ServerKey("this-is-an-invalid-server-key")
 	let exampleToken = DeviceToken("this-is-an-invalid-token")
+	let exampleTopic = Topic("cats", "dogs")
 	let message = Message(payload: Payload(text: "What's up!"))
 
 	var sut: Firebase!
@@ -32,7 +33,15 @@ class FirebaseTests: XCTestCase {
 	/// I'm not checking any results (it'll still pass if there is no internet connection). It's mostly useful to see if all the api including curl are present on the system
 
 	func testSimpleSending() throws {
-		let capturedResponse: FirebaseResponse? = try? sut.send(message: message, to: exampleToken)
+		let capturedResponse: FirebaseDeviceResponse? = try? sut.send(message: message, to: exampleToken)
+
+		XCTAssertNotNil(capturedResponse)
+		XCTAssertNotNil(capturedResponse?.error)
+		XCTAssertEqual(capturedResponse?.success, false)
+	}
+
+	func testTopicSending() throws {
+		let capturedResponse: FirebaseTopicResponse? = try sut.send(message: message, to: exampleTopic)
 
 		XCTAssertNotNil(capturedResponse)
 		XCTAssertNotNil(capturedResponse?.error)


### PR DESCRIPTION
There are two Response types now, each associated with a Target and ensured at compile time.